### PR TITLE
CI and Windows build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -72,8 +72,8 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          nmake
-          cp ./debug/libftdi.lib ./ftdi.lib
+          cmake --build . --config Release
+          cp ./release/libftdi.lib ./ftdi.lib
     
       - name: Build
         run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -71,8 +71,8 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake --config Release ..
-          cmake --config Release --build .
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake -DCMAKE_BUILD_TYPE=Release --build .
           cp ./Release/libftdi.lib ./ftdi.lib
     
       - name: Build

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           qmake DSP568xx_jtag_flasher.pro
+          make
           
       - name: Upload binary
         uses: actions/upload-artifact@v4
@@ -59,6 +60,7 @@ jobs:
         run: |
           cd $Env:GITHUB_WORKSPACE
           qmake DSP568xx_jtag_flasher.pro
+          make
           windeployqt bin\*.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           
       - name: Upload zip

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          host: 'linux'
+          target: 'desktop'
+          arch: 'gcc_64'
+          cache: true
+          cache-key-prefix: install-qt-action
+          
+      # Runs a set of commands using the runners shell
+      - name: Build
+        run: |
+          cd $GITHUB_WORKSPACE
+          qmake DSP568xx_jtag_flasher.pro
+          
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsp-linux
+          path: bin/
+  
+  build-windows:
+    runs-on: windows-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1
+      
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          target: desktop
+          arch: win64_msvc2019_64
+          cache: true
+          cache-key-prefix: install-qt-action
+     
+      - name: Build
+        run: |
+          cd $Env:GITHUB_WORKSPACE
+          qmake DSP568xx_jtag_flasher.pro
+          windeployqt bin\*.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
+          
+      - name: Upload zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsp-windows
+          path: bin\

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libftdi-dev
+          version: 1.0
       
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
@@ -60,7 +65,7 @@ jobs:
         run: |
           cd $Env:GITHUB_WORKSPACE
           qmake DSP568xx_jtag_flasher.pro
-          make
+          nmake
           windeployqt bin\*.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           
       - name: Upload zip

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -84,10 +84,10 @@ jobs:
 
           qmake DSP568xx_jtag_flasher.pro
           nmake
-          windeployqt DSP568xx_jtag_flasher.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
+          windeployqt debug/DSP568xx_jtag_flasher.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           
       - name: Upload zip
         uses: actions/upload-artifact@v4
         with:
           name: dsp-flasher-windows
-          path: DSP568xx_jtag_flasher.exe
+          path: debug/DSP568xx_jtag_flasher.exe

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -71,9 +71,9 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
-          cmake -DCMAKE_BUILD_TYPE=Release --build .
-          cp ./Release/libftdi.lib ./ftdi.lib
+          cmake ..
+          nmake
+          cp ./debug/libftdi.lib ./ftdi.lib
     
       - name: Build
         run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,11 +17,14 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
+          aqtversion: '==3.1.*'
+          version: '6.5.3'
           host: 'linux'
           target: 'desktop'
           arch: 'gcc_64'
           cache: true
           cache-key-prefix: install-qt-action
+          modules: 'qtwebsockets'
           
       # Runs a set of commands using the runners shell
       - name: Build
@@ -45,10 +48,12 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
+          version: 6.5.3
           target: desktop
           arch: win64_msvc2019_64
           cache: true
           cache-key-prefix: install-qt-action
+          modules: 'qtwebsockets'
      
       - name: Build
         run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Clone libftdi
         uses: actions/checkout@v6
         with:
-          repository: 'avrdudes/libftdi'
+          repository: 'stonedDiscord/libftdi'
+          ref: 'windows'
           path: libftdi
 
       - name: Build libftdi

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -71,9 +71,9 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
-          cmake --build .
-          cp ./Debug/libftdi.lib ./ftdi.lib
+          cmake --config Release ..
+          cmake --config Release --build .
+          cp ./Release/libftdi.lib ./ftdi.lib
     
       - name: Build
         run: |
@@ -89,4 +89,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dsp-flasher-windows
-          path: debug/DSP568xx_jtag_flasher.exe
+          path: release/DSP568xx_jtag_flasher.exe

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Build
         run: |
           cd $Env:GITHUB_WORKSPACE
-          qmake DSP568xx_jtag_flasher.pro -L$$GITHUB_WORKSPACE/libftdi/
-          nmake
+          qmake DSP568xx_jtag_flasher.pro
+          nmake -L$GITHUB_WORKSPACE/libftdi/
           windeployqt DSP568xx_jtag_flasher.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           
       - name: Upload zip

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -49,7 +49,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
-      
+
+      - uses: actions/checkout@v6
+        with:
+          repository: 'avrdudes/libftdi'
+          path: libftdi
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
@@ -62,7 +67,7 @@ jobs:
       - name: Build
         run: |
           cd $Env:GITHUB_WORKSPACE
-          qmake DSP568xx_jtag_flasher.pro
+          qmake DSP568xx_jtag_flasher.pro -L$$GITHUB_WORKSPACE/libftdi/
           nmake
           windeployqt DSP568xx_jtag_flasher.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -72,6 +72,7 @@ jobs:
           cd build
           cmake ..
           cmake --build .
+          cp ./Debug/libftdi.lib ./ftdi.lib
     
       - name: Build
         run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd $Env:GITHUB_WORKSPACE
           qmake DSP568xx_jtag_flasher.pro
-          nmake -L$GITHUB_WORKSPACE/libftdi/
+          nmake -l ${GITHUB_WORKSPACE}/libftdi/
           windeployqt DSP568xx_jtag_flasher.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           
       - name: Upload zip

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -71,7 +71,7 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          make
+          cmake --build .
     
       - name: Build
         run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -66,9 +66,11 @@ jobs:
      
       - name: Build
         run: |
-          cd $Env:GITHUB_WORKSPACE
+          $libftdiInc = Join-Path $Env:GITHUB_WORKSPACE 'libftdi\include'
+          $Env:INCLUDE = "$Env:INCLUDE;$libftdiInc"
+
           qmake DSP568xx_jtag_flasher.pro
-          nmake -l ${GITHUB_WORKSPACE}/libftdi/
+          nmake
           windeployqt DSP568xx_jtag_flasher.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           
       - name: Upload zip

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -66,7 +66,7 @@ jobs:
           path: libftdi
 
       - name: Build libftdi
-        working-directory: '${{ env.GITHUB_WORKSPACE }}/libftdi'
+        working-directory: 'libftdi'
         run: |
           mkdir build
           cd build

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -84,7 +84,6 @@ jobs:
 
           qmake DSP568xx_jtag_flasher.pro
           nmake
-          windeployqt debug/DSP568xx_jtag_flasher.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           
       - name: Upload zip
         uses: actions/upload-artifact@v4

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,7 +29,6 @@ jobs:
           arch: 'gcc_64'
           cache: true
           cache-key-prefix: install-qt-action
-          modules: 'qtwebsockets'
           
       # Runs a set of commands using the runners shell
       - name: Build
@@ -41,8 +40,8 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: dsp-linux
-          path: bin/
+          name: dsp-flasher-linux
+          path: DSP568xx_jtag_flasher
   
   build-windows:
     runs-on: windows-latest
@@ -59,17 +58,16 @@ jobs:
           arch: win64_msvc2019_64
           cache: true
           cache-key-prefix: install-qt-action
-          modules: 'qtwebsockets'
      
       - name: Build
         run: |
           cd $Env:GITHUB_WORKSPACE
           qmake DSP568xx_jtag_flasher.pro
           nmake
-          windeployqt bin\*.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
+          windeployqt DSP568xx_jtag_flasher.exe --release --no-translations --no-compiler-runtime --no-opengl-sw
           
       - name: Upload zip
         uses: actions/upload-artifact@v4
         with:
-          name: dsp-windows
-          path: bin\
+          name: dsp-flasher-windows
+          path: DSP568xx_jtag_flasher.exe

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -50,11 +50,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
 
-      - uses: actions/checkout@v6
-        with:
-          repository: 'avrdudes/libftdi'
-          path: libftdi
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
@@ -63,11 +58,27 @@ jobs:
           arch: win64_msvc2019_64
           cache: true
           cache-key-prefix: install-qt-action
-     
+
+      - name: Clone libftdi
+        uses: actions/checkout@v6
+        with:
+          repository: 'avrdudes/libftdi'
+          path: libftdi
+
+      - name: Build libftdi
+        working-directory: '${{ env.GITHUB_WORKSPACE }}/libftdi'
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+    
       - name: Build
         run: |
           $libftdiInc = Join-Path $Env:GITHUB_WORKSPACE 'libftdi\include'
+          $libftdiLib = Join-Path $Env:GITHUB_WORKSPACE 'libftdi\build'
           $Env:INCLUDE = "$Env:INCLUDE;$libftdiInc"
+          $Env:LIB = "$Env:LIB;$libftdiLib"
 
           qmake DSP568xx_jtag_flasher.pro
           nmake

--- a/DSP568xx_jtag_flasher.pro
+++ b/DSP568xx_jtag_flasher.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 CONFIG += console
 CONFIG -= app_bundle
 CONFIG -= qt
-CONFIG+=debug
+
 LIBS += -lftdi
 
 

--- a/flash_over_jtag.c
+++ b/flash_over_jtag.c
@@ -74,6 +74,9 @@ operations operation=VIEW_MEMORY;				/* what the tool is going to do: view flash
 
 mem_read_constants mem_read;					/* parameters for reading memory */
 
+#ifndef PATH_MAX
+#define PATH_MAX 250
+#endif
 
 #define FILENAME_MAX_LEN	PATH_MAX
 char s_rec_filename[PATH_MAX+1]="";		/* name of the s-record file */
@@ -314,3 +317,4 @@ int main (int argc,char *argv[]) {
     }
     return(SUCESS);
 }
+

--- a/hw_access.h
+++ b/hw_access.h
@@ -28,8 +28,8 @@
 
 /**************************************************************************/
 
-#define JTAG_TCK_SET		pport_data|=JTAG_TCK_MASK;outp(pport_data)
-#define JTAG_TCK_RESET		pport_data&=~JTAG_TCK_MASK;outp(pport_data)
+#define JTAG_TCK_SET		pport_data|=JTAG_TCK_MASK;jtag_outp(pport_data)
+#define JTAG_TCK_RESET		pport_data&=~JTAG_TCK_MASK;jtag_outp(pport_data)
 
 #define JTAG_TMS_SET		pport_data|=JTAG_TMS_MASK
 #define JTAG_TMS_RESET		pport_data&=~JTAG_TMS_MASK
@@ -39,18 +39,19 @@
 
 #define JTAG_TDI_ASSIGN(i)	if (i&0x0001) JTAG_TDI_SET else JTAG_TDI_RESET
 
-#define JTAG_TRST_SET		pport_data|=JTAG_TRST_MASK;outp(pport_data)
-#define JTAG_TRST_RESET		pport_data&=~JTAG_TRST_MASK;outp(pport_data)
+#define JTAG_TRST_SET		pport_data|=JTAG_TRST_MASK;jtag_outp(pport_data)
+#define JTAG_TRST_RESET		pport_data&=~JTAG_TRST_MASK;jtag_outp(pport_data)
 
-#define JTAG_RESET_SET		pport_data&=~JTAG_RESET_MASK;outp(pport_data)
-#define JTAG_RESET_RESET	pport_data|=JTAG_RESET_MASK;outp(pport_data)
+#define JTAG_RESET_SET		pport_data&=~JTAG_RESET_MASK;jtag_outp(pport_data)
+#define JTAG_RESET_RESET	pport_data|=JTAG_RESET_MASK;jtag_outp(pport_data)
 
-#define JTAG_TDO_VALUE				((inp() & JTAG_TDO_MASK) ? 1 : 0)
+#define JTAG_TDO_VALUE				((jtag_inp() & JTAG_TDO_MASK) ? 1 : 0)
 
 // extern "C" unsigned int initdelay(void);
 // extern "C" void delay50ns(void);
 
 #define INIT_WAIT_FUNCTION
-#define WAIT_100_NS			outp(pport_data)
+#define WAIT_100_NS			jtag_outp(pport_data)
 
 #endif
+

--- a/jtag.c
+++ b/jtag.c
@@ -106,13 +106,13 @@ int open_port() {
     return 0;
 }
 
-void outp(uint8_t data)
+void jtag_outp(uint8_t data)
 {
     ftdi_write_data(ftdic, &data, 1);
     return;
 }
 
-uint8_t inp()
+uint8_t jtag_inp()
 {
     uint8_t ret = 0;
     int rc = ftdi_read_pins(ftdic, &ret);
@@ -903,6 +903,7 @@ void once_flash_read(unsigned char program_memory, unsigned int start_addr,
     printf("\n");
     printf("\nReading memory done, %#lx word(s) read.\n", count);
 }
+
 
 
 


### PR DESCRIPTION
Visual Studio will not allow you to call a function inp and outp and PATH_MAX was missing, otherwise everything was pretty portable.
For Windows I used the AVRDUDESS fork of libftdi so you don't have to replace the driver with libusb.